### PR TITLE
update pteid-mw.spec 

### DIFF
--- a/pteid-mw-pt/_src/eidmw/pteid-mw.spec
+++ b/pteid-mw-pt/_src/eidmw/pteid-mw.spec
@@ -198,8 +198,6 @@ mkdir -p $RPM_BUILD_ROOT/usr/share/mime/packages
  %suse_update_desktop_file -i pteid-mw-gui Office Presentation
   export NO_BRP_CHECK_RPATH=true
 %endif
-%clean
-rm -rf $RPM_BUILD_ROOT
 
 %post
 ln -s -f /usr/local/lib/libpteidcommon.so.2.0.0 /usr/local/lib/libpteidcommon.so
@@ -224,8 +222,8 @@ ln -s -f /usr/local/lib/libCMDServices.so.1.0.0 /usr/local/lib/libCMDServices.so
 ln -s -f /usr/local/lib/libCMDServices.so.1.0.0 /usr/local/lib/libCMDServices.so.1
 ln -s -f /usr/local/lib/libCMDServices.so.1.0.0 /usr/local/lib/libCMDServices.so.1.0
 
-ln -s /usr/share/pixmaps/pteid-signature.png /usr/share/icons/hicolor/64x64/mimetypes/application-x-signedcc.png
-ln -s /usr/share/pixmaps/pteid-signature.png /usr/share/icons/hicolor/64x64/mimetypes/gnome-mime-application-x-signedcc.png
+ln -s -f /usr/share/pixmaps/pteid-signature.png /usr/share/icons/hicolor/64x64/mimetypes/application-x-signedcc.png
+ln -s -f /usr/share/pixmaps/pteid-signature.png /usr/share/icons/hicolor/64x64/mimetypes/gnome-mime-application-x-signedcc.png
 
 %if 0%{?fedora} || 0%{?centos_version}
 # BLURP: Add usr local to ldconf

--- a/pteid-mw-pt/_src/eidmw/pteid-mw.spec
+++ b/pteid-mw-pt/_src/eidmw/pteid-mw.spec
@@ -80,11 +80,11 @@ Conflicts:  cartao_de_cidadao
 
 License:        GPLv2+
 Group:          System/Libraries
-Version:        3.0.20
+Version:        3.0.21
 %if 0%{?fedora}
-Release:        2%{?dist}
+Release:        1%{?dist}
 %else
-Release:        2
+Release:        1%{?dist}
 %endif
 Summary:        Portuguese eID middleware
 Url:            https://svn.gov.pt/projects/ccidadao/
@@ -95,6 +95,8 @@ Patch2:         0002-openssl1.1-support-eidguiV2.patch-from.patch
 Patch3:         0003-Support-xml-security-c-2.0.2.patch
 Patch4:         0004-add-pt.gov.autenticacao.appdata.xml.patch
 Patch5:         0005-Fedora-30-Qt-Fixup-for.patch
+Patch6:         6d7c7a86eb54a85f5796488a7d7cc92dbaa87f28.patch
+Patch7:         31491690ebce937fbd7fa167767e0cc6308ec66c.patch
 
 
 %if 0%{?suse_version}
@@ -114,7 +116,7 @@ Requires(postun): /usr/bin/gtk-update-icon-cache
  in certain websites and sign documents.
 
 %prep
-%setup -q -n autenticacao.gov-3.0.20
+%setup -q -n autenticacao.gov-%{version}
 %if 0%{?fedora} || 0%{?rhel} >= 8
 %patch1 -p1
 %patch2 -p1
@@ -122,11 +124,13 @@ Requires(postun): /usr/bin/gtk-update-icon-cache
 %patch3 -p1
 %patch4 -p1
 %patch5 -p1
+%patch6 -p1
+%patch7 -p1
 
 cd ..
-mv autenticacao.gov-3.0.20 autenticacao.gov-3.0.20.tmp
-mv autenticacao.gov-3.0.20.tmp/pteid-mw-pt/_src/eidmw/ autenticacao.gov-3.0.20
-cd autenticacao.gov-3.0.20
+mv autenticacao.gov-%{version} autenticacao.gov-%{version}.tmp
+mv autenticacao.gov-%{version}.tmp/pteid-mw-pt/_src/eidmw/ autenticacao.gov-%{version}
+cd autenticacao.gov-%{version}
 
 # create dirs that git doesn't
 #mkdir lib jar
@@ -296,6 +300,9 @@ fi
 /usr/local/share/certs
 
 %changelog
+* Sun Dec 01 2019 Sérgio Basto <sergio@serjux.com> - 3.0.21-1
+- 3.0.21
+
 * Fri Nov 29 2019 Sérgio Basto <sergio@serjux.com> - 3.0.20-2
 - Enable build for EPEL 7 and EPEL 8 build with or higher:
   libzip 1.5.2-1

--- a/pteid-mw-pt/_src/eidmw/pteid-mw.spec
+++ b/pteid-mw-pt/_src/eidmw/pteid-mw.spec
@@ -22,13 +22,14 @@
 %endif
 %endif
 
-%define svn_revision 6072
-
 Name:           pteid-mw
-BuildRequires:  pcsc-lite-devel make swig
+BuildRequires:  pcsc-lite-devel
+BuildRequires:  make
+BuildRequires:  swig
 BuildRequires:  libzip-devel
 BuildRequires:  openjpeg2-devel
-Requires:       pcsc-lite curl
+Requires:       pcsc-lite
+Requires:       curl
 
 
 %if 0%{?suse_version}
@@ -51,26 +52,28 @@ BuildRequires:  libxml-security-c-devel
 %endif
 
 %if 0%{?fedora} || 0%{?centos_ver}
+BuildRequires:  gcc-c++
 BuildRequires:  java-1.8.0-openjdk-devel
-Requires:       poppler-qt5
-Requires:       pcsc-lite-ccid
-Requires:       qt5
 
 BuildRequires:  qt5-qtbase-devel
 BuildRequires:  qt5-qtdeclarative-devel
 BuildRequires:  qt5-qtquickcontrols2-devel
 BuildRequires:  qt5-qttools-devel
-#Just install the big qt5 meta-package
-BuildRequires:  qt5
 BuildRequires:  libpng-devel
 
-BuildRequires:  xml-security-c-devel
-BuildRequires:  poppler-qt5-devel
-BuildRequires:  cairo-devel gcc gcc-c++ xerces-c-devel
-BuildRequires:  qt-devel pcsc-lite-ccid curl-devel
-
+BuildRequires:  cairo-devel
+BuildRequires:  curl-devel
 BuildRequires:  openssl-devel
+BuildRequires:  pcsc-lite-ccid
+BuildRequires:  poppler-qt5-devel
+BuildRequires:  xerces-c-devel
+BuildRequires:  xml-security-c-devel
 
+#BuildRequires: kf5-kinit-devel
+%{?kf5_kinit_requires}
+
+Requires:       poppler-qt5
+Requires:       pcsc-lite-ccid
 %endif
 
 Conflicts:  cartao_de_cidadao
@@ -79,9 +82,9 @@ License:        GPLv2+
 Group:          System/Libraries
 Version:        3.0.20
 %if 0%{?fedora}
-Release:        1%{?dist}
+Release:        2%{?dist}
 %else
-Release:        1
+Release:        2
 %endif
 Summary:        Portuguese eID middleware
 Url:            https://svn.gov.pt/projects/ccidadao/
@@ -111,7 +114,15 @@ Requires(postun): /usr/bin/gtk-update-icon-cache
  in certain websites and sign documents.
 
 %prep
-%autosetup -p1 -n autenticacao.gov-3.0.20
+%setup -q -n autenticacao.gov-3.0.20
+%if 0%{?fedora} || 0%{?rhel} >= 8
+%patch1 -p1
+%patch2 -p1
+%endif
+%patch3 -p1
+%patch4 -p1
+%patch5 -p1
+
 cd ..
 mv autenticacao.gov-3.0.20 autenticacao.gov-3.0.20.tmp
 mv autenticacao.gov-3.0.20.tmp/pteid-mw-pt/_src/eidmw/ autenticacao.gov-3.0.20
@@ -287,6 +298,15 @@ fi
 /usr/local/share/certs
 
 %changelog
+* Fri Nov 29 2019 Sérgio Basto <sergio@serjux.com> - 3.0.20-2
+- Enable build for EPEL 7 and EPEL 8 build with or higher:
+  libzip 1.5.2-1
+  poppler 0.66.0-11
+  poppler-data 0.4.9-1
+  xalan-c 	1.11.0-16
+  xerces-c 	3.2.2-3
+  xml-security-c 2.0.2-4 (patched)
+
 * Sun Nov 17 2019 Sérgio Basto <sergio@serjux.com> - 3.0.20-1
 - 3.0.20
 


### PR DESCRIPTION
Olá, 
Por causa o mySNS, acabei este fim de semana de criar rpms para Fedora 30+ e Centos 7 e 8 o resultado é este [1] e funciona relativamente bem ... 

Abraços. hope this helps

O patches para compilar com Qt F30 entre outras coisas estão em [2] , o código dos rpms estão em [3] 

[1]
https://copr.fedorainfracloud.org/coprs/sergiomb/pteid-mw/package/pteid-mw/

[2]
https://github.com/sergiomb2/autenticacao.gov/tree/patches

[3]
https://github.com/sergiomb2/autenticacao.gov_rpms