### PR TITLE
debian: bump deb version to 3.0.21, fix build-deps

### DIFF
--- a/pteid-mw-pt/_src/eidmw/debian/changelog
+++ b/pteid-mw-pt/_src/eidmw/debian/changelog
@@ -1,3 +1,9 @@
+pteid-mw (3.0.21+git20191206-3795abb9-1) UNRELEASED; urgency=medium
+
+  * Version is now 3.0.21
+  * The current use of libxml-security-c-dev depends on a version lower than 2.0
+
+ -- Marcos Marado <mindboosternoori@gmail.com>  Sun, 07 Dec 2019 18:17:12 +0100
 pteid-mw (3.0.20+git20190930-e547bd9d-1) UNRELEASED; urgency=medium
 
   * Address change bugfix for cards issued since May 2019

--- a/pteid-mw-pt/_src/eidmw/debian/control
+++ b/pteid-mw-pt/_src/eidmw/debian/control
@@ -18,7 +18,7 @@ Build-Depends: debhelper (>= 7.0.50~),
                qml-module-qtquick-controls2,	
                libssl1.0-dev,
                libxerces-c-dev,
-               libxml-security-c-dev,
+               libxml-security-c-dev (< 2),
                swig,
                libcurl4-nss-dev
 Standards-Version: 3.9.1


### PR DESCRIPTION
* Version is now 3.0.21
* The current use of libxml-security-c-dev depends on a version lower than 2.0