### PR TITLE
Gestão de SSO delegada ao cliente da API

### DIFF
--- a/pteid-mw-pt/_src/eidmw/applayer/APLCard.cpp
+++ b/pteid-mw-pt/_src/eidmw/applayer/APLCard.cpp
@@ -232,6 +232,12 @@ void APL_Card::SignXadesAIndividual(const char ** paths, unsigned int n_paths, c
 	SignIndividual(paths, n_paths, output_dir, false, true);
 }
 
+void APL_Card::setSSO(bool enable)
+{
+	getCalReader()->setSSO(enable);
+}
+
+
 
 // Implementation of the PIN-caching version of SignXades()
 // It signs each input file seperately and creates a .zip container for each

--- a/pteid-mw-pt/_src/eidmw/applayer/APLCard.h
+++ b/pteid-mw-pt/_src/eidmw/applayer/APLCard.h
@@ -151,6 +151,8 @@ public:
 	  */
 	CReader *getCalReader() const;
 
+	virtual void setSSO(bool enable = false);
+
 protected:
 	/**
 	  * Constructor

--- a/pteid-mw-pt/_src/eidmw/eidlib/eidlib.h
+++ b/pteid-mw-pt/_src/eidmw/eidlib/eidlib.h
@@ -614,6 +614,14 @@ public:
 	 */
     PTEIDSDK_API virtual PTEID_ByteArray sendAPDU(const PTEID_ByteArray& cmd);
 
+	/**
+	* Sets SSO on the card reader to allow pin caching
+	* Caller is responsible for restoring the state after the signing
+	* session is concluded
+	* @param enable boolean that will set the SSO state
+	*/
+	PTEIDSDK_API virtual void SetSSO(bool enable = false);
+
  	/**
 	 * Raw RSA signature with PCKS #1 padding.
 	 * @param data holds the data to be signed, at most 32 bytes.

--- a/pteid-mw-pt/_src/eidmw/eidlib/eidlibCard.cpp
+++ b/pteid-mw-pt/_src/eidmw/eidlib/eidlibCard.cpp
@@ -121,6 +121,16 @@ PTEID_ByteArray PTEID_Card::sendAPDU(const PTEID_ByteArray& cmd)
 	return out;
 }
 
+void PTEID_Card::SetSSO(bool enable)
+{
+	BEGIN_TRY_CATCH
+
+	APL_Card *pcard = static_cast<APL_Card *>(m_impl);
+	pcard->setSSO(enable);
+
+	END_TRY_CATCH
+}
+
 PTEID_ByteArray PTEID_Card::Sign(const PTEID_ByteArray& data, bool signatureKey)
 {
 	PTEID_ByteArray out;

--- a/pteid-mw-pt/_src/eidmw/release_data.h
+++ b/pteid-mw-pt/_src/eidmw/release_data.h
@@ -6,7 +6,7 @@
 #define BASE_VERSION1            3 
 #define BASE_VERSION2            1 
 #define BASE_VERSION3            0 
-#define REVISION_NUM             3830 
-#define REVISION_NUM_STRING      "3830" 
-#define REVISION_HASH_STRING     "46a1659f" 
+#define REVISION_NUM             3858 
+#define REVISION_NUM_STRING      "3858" 
+#define REVISION_HASH_STRING     "c767718d" 
 #endif //__RELEASE_DATA_H__ 


### PR DESCRIPTION
Este PR da resposta ao problema indicado no issue #11. 
Fa-ló expondo o método `setSSO` ao consumidor da API. Este fica responsável pela gestão do SSO.

Haveria claramente outras forma de atacar o problema, não expondo o método, por exemplo reproduzindo o conceito de sessão de assinatura utilizado na assinatura de PDFs em batch.

Esta solução deixa mais responsabilidade ao _caller_  mas é mais versátil e dispensa código especifico para suportar o comportamento dependendo do artefacto a ser assinado (ficheiros pdf, hashes etc).

Do ponto de vista prático pessoal, não me forçou a alterar os ficheiros **.i**, dado que soluções alternativas obrigariam por certo à definição de novas _bridges_ de tipos de dados. Para isso teria de levar a cabo uma aprendizagem sobre SWIG para a qual não tenho tempo neste momento (embora pareça interessante).