### PR TITLE
flatpak: Suporte para Wayland

### DIFF
--- a/pteid-mw-pt/_src/eidmw/pt.gov.autenticacao.yml
+++ b/pteid-mw-pt/_src/eidmw/pt.gov.autenticacao.yml
@@ -6,6 +6,7 @@ command: eidguiV2
 finish-args:
   - --socket=pcsc
   - --socket=cups
+  - --socket=wayland
   - --socket=x11
   - --device=dri
   - --filesystem=home


### PR DESCRIPTION
Uso Sway e notei que a permissão necessária para ambientes Wayland não está ligada por omissão (`--socket=wayland`).

Quando liguei pareceu estar ok (assinei um documento, vi os dados pessoais do meu cartão), pelo que deve ser seguro deixar sempre ligado.