### PR TITLE
flatpak: Melhorar interação com ficheiros

### DIFF
--- a/pteid-mw-pt/_src/eidmw/pt.gov.autenticacao.yml
+++ b/pteid-mw-pt/_src/eidmw/pt.gov.autenticacao.yml
@@ -9,7 +9,9 @@ finish-args:
   - --socket=wayland
   - --socket=x11
   - --device=dri
-  - --filesystem=home
+  - --filesystem=home/.pteid-ng
+  - --filesystem=home/.PTEID_0.log
+  - --filesystem=xdg-config/pteid.conf
   - --share=ipc
   - --share=network
 modules:

--- a/pteid-mw-pt/_src/eidmw/pt.gov.autenticacao.yml
+++ b/pteid-mw-pt/_src/eidmw/pt.gov.autenticacao.yml
@@ -133,6 +133,7 @@ modules:
       - PREFIX_DIR = /app/
     build-commands:
       -  sed -i 's/pteid-scalable/pt.gov.autenticacao/g' debian/pteid-mw-gui.desktop
+      -  sed -i -E 's/^Exec=.* eidguiV2$/Exec=eidguiV2/g' debian/pteid-mw-gui.desktop
       -  install -Dm644 debian/pteid-mw-gui.desktop /app/share/applications/pt.gov.autenticacao.desktop
       -  install -Dm644 debian/pteid-scalable.svg /app/share/icons/hicolor/scalable/apps/pt.gov.autenticacao.svg
       -  install -Dm644 pt.gov.autenticacao.metainfo.xml /app/share/appdata/pt.gov.autenticacao.metainfo.xml


### PR DESCRIPTION
Este PR retira a variável de ambiente `QT_QPA_PLATFORMTHEME=gtk3` que impedia os diálogos de abrir/guardar ficheiros de interagir com os [portais adequados](https://flatpak.github.io/xdg-desktop-portal/).
Assim, sem mais nenhuma alteração, passa a ser possível abrir e guardar ficheiros de qualquer parte do sistema (não só da *home* do utilizador).

Adicionalmente, aperta as permissões da *sandbox* aplicada ao autenticacao.gov, passando apenas a permitir acesso aos ficheiros de configuração/cache respetivos.
Estes (669fcd0) foram todos os que vi a aplicação escrever durante utilização normal, mas é possível que tenham escapado alguns. 