### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/pteid-mw-pt/_src/eidmw/pteid-poppler/fofi/FoFiType1C.cc
+++ b/pteid-mw-pt/_src/eidmw/pteid-poppler/fofi/FoFiType1C.cc
@@ -892,6 +892,9 @@ void FoFiType1C::convertToType0(char *psName, int *codeMap, int nCodes,
       }
     }
 
+    if (fd >= nFDs)
+	    continue;
+
     // font dictionary (unencrypted section)
     (*outputFunc)(outputStream, "16 dict begin\n", 14);
     (*outputFunc)(outputStream, "/FontName /", 11);


### PR DESCRIPTION
Hi autenticacao.gov Development Team,

Our tool identified a potential heap-based buffer over-read vulnerability in a clone function`convertToType0()` in `pteid-mw-pt/_src/eidmw/pteid-poppler/fofi/FoFiType1C.cc` sourced from [poppler/poppler](https://gitlab.freedesktop.org/poppler/poppler). These issues, originally reported in [CVE-2021-21309](https://nvd.nist.gov/vuln/detail/CVE-2021-21309), were resolved in the repository via this commit [poppler/poppler@da63c35](https://gitlab.freedesktop.org/poppler/poppler/-/commit/da63c35549e8852a410946ab016a3f25ac701bdf).

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience.