### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/pteid-mw-pt/_src/eidmw/pteid-poppler/poppler/Stream.cc
+++ b/pteid-mw-pt/_src/eidmw/pteid-poppler/poppler/Stream.cc
@@ -1753,10 +1753,11 @@ int CCITTFaxStream::lookChar() {
     // 2-D encoding
     if (nextLine2D) {
       for (i = 0; codingLine[i] < columns; ++i) {
-	refLine[i] = codingLine[i];
+	      refLine[i] = codingLine[i];
       }
-      refLine[i++] = columns;
-      refLine[i] = columns;
+      for (; i < columns + 2; ++i) {
+	      refLine[i] = columns;
+      }
       codingLine[0] = 0;
       a0i = 0;
       b1i = 0;


### PR DESCRIPTION
Hi autenticacao.gov Development Team,

Our tool identified another potential vulnerability in a clone function `CCITTFaxStream::lookChar()` in `pteid-mw-pt/_src/eidmw/pteid-poppler/poppler/Stream.cc` sourced from [poppler/poppler](https://cgit.freedesktop.org/poppler/poppler). These issues, originally reported in [CVE-2013-1790](https://nvd.nist.gov/vuln/detail/CVE-2013-1790), were resolved in the repository via this commit [poppler/poppler@b1026b5](https://cgit.freedesktop.org/poppler/poppler/commit/?h=poppler-0.22&id=b1026b5978c385328f2a15a2185c599a563edf91).

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience.